### PR TITLE
Updated AWS Well-Architected Framework Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 
 ## Whitepapers
 
-* [AWS Well-Architected Framework](https://d1.awsstatic.com/whitepapers/architecture/AWS_Well-Architected_Framework.pdf)
+* [AWS Well-Architected Framework](https://docs.aws.amazon.com/wellarchitected/latest/framework/wellarchitected-framework.pdf)
 * [AWS Well-Architected Framework: Operational Excellence Pillar](https://d1.awsstatic.com/whitepapers/architecture/AWS-Operational-Excellence-Pillar.pdf)
 * [AWS Well-Architected Framework: Reliability Pillar](https://d1.awsstatic.com/whitepapers/architecture/AWS-Reliability-Pillar.pdf)
 * [AWS Well-Architected Framework: Security Pillar](https://d1.awsstatic.com/whitepapers/architecture/AWS-Security-Pillar.pdf)


### PR DESCRIPTION
The [previous link](https://d1.awsstatic.com/whitepapers/architecture/AWS_Well-Architected_Framework.pdf) takes to an archived version of the whitepaper, which lists [this](https://docs.aws.amazon.com/wellarchitected/latest/framework/wellarchitected-framework.pdf) as the updated version

---

## Resource

AWS Well-Architected Framework

https://docs.aws.amazon.com/wellarchitected/latest/framework/wellarchitected-framework.pdf

## What is this

An updated version of the previously-linked whitepaper.

## Why should this be added

The previous version has been archived.