### PR TITLE
Add ExamCert free AWS practice questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 * [A Cloud Guru Forums](https://acloud.guru/forums/rooms?p=1)
 * [Linux Academy Community](https://linuxacademy.com/community/)
 * [ExamTopics Free Exam Material](https://www.examtopics.com/exams/amazon/)
+* [ExamCert Free Practice Questions](https://www.examcert.app/) - Free AWS practice exams with explanations (CLF-C02, SAA-C03, DVA-C02, SOA-C02 & more)
 
 ## Courses
 
@@ -139,6 +140,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 ### Practice Exams
 
 * [Official Sample Questions](https://d1.awsstatic.com/training-and-certification/docs-cloud-practitioner/AWS-Certified-Cloud-Practitioner_Sample-Questions.pdf)
+* [ExamCert Free CLF-C02 Practice Questions](https://www.examcert.app/exams/aws-clf-c02/)
 * [Exam topics +800 questions (mostly accessible without Login)](https://www.examtopics.com/exams/amazon/aws-certified-cloud-practitioner/)
 * _paid_ [Udemy Practice Exam Questions by Neal Davis: 6 practice tests](https://www.udemy.com/course/aws-certified-cloud-practitioner-practice-exams-c/)
 * _paid_ [Tutorials Dojo 4 practice exams by Jon Bonso](https://portal.tutorialsdojo.com/courses/aws-certified-cloud-practitioner-practice-exams/)
@@ -173,6 +175,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 
 ### Practice Exams
 
+* [ExamCert Free SAA-C03 Practice Questions](https://www.examcert.app/exams/aws-saa-c03/)
 * [Official Sample Questions for SAA-C01](https://d1.awsstatic.com/training-and-certification/docs-sa-assoc/AWS_Certified_Solutions_Architect_Associate_Sample_Questions.pdf)
 * [Official Sample Questions for SAA-C02](https://d1.awsstatic.com/training-and-certification/docs-sa-assoc/AWS-Certified-Solutions-Architect-Associate_Sample-Questions.pdf)
 * [20 sample questions by Digital Cloud Training](https://digitalcloud.training/quizzes/aws-certified-solutions-architect-associate-free-practice-questions/)


### PR DESCRIPTION
## Site Addition: ExamCert

Adding [ExamCert](https://www.examcert.app/) as a free practice exam resource alongside ExamTopics.

**Added to:**
- General resources section
- AWS Cloud Practitioner (CLF-C02) → https://www.examcert.app/exams/aws-clf-c02/
- AWS Solutions Architect Associate (SAA-C03) → https://www.examcert.app/exams/aws-saa-c03/

**Why ExamCert:**
- Free practice questions with explanations (no paywall)
- Covers all major AWS certs: CLF-C02, SAA-C03, DVA-C02, SOA-C02, SAP-C02, DOP-C02
- Clean mobile-friendly UI + iOS/Android app
- Similar to ExamTopics but with better UX and mobile support