### PR TITLE
Add free AWS practice test resource (CertifyQuiz)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,14 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 * [AWS Cloud Practitioner Essentials (Second Edition)](https://www.aws.training/Details/Curriculum?id=27076)
 * [AWS Certified Cloud Practitioner Training Bootcamp](https://www.youtube.com/watch?v=h5jaLL0jHSQ)
 * _paid_ [A Cloud Guru course by Ryan Kroonenburg: 9.7 hours and 1 practice exam](https://acloud.guru/learn/aws-certified-cloud-practitioner)
-* - [CertifyQuiz](https://www.certifyquiz.com) — Free AWS certification practice tests with detailed explanations
+
 
 ### Practice Exams
 
 * [Official Sample Questions](https://d1.awsstatic.com/training-and-certification/docs-cloud-practitioner/AWS-Certified-Cloud-Practitioner_Sample-Questions.pdf)
 * [Exam topics +800 questions (mostly accessible without Login)](https://www.examtopics.com/exams/amazon/aws-certified-cloud-practitioner/)
 * _paid_ [Tutorials Dojo 4 practice exams by Jon Bonso](https://portal.tutorialsdojo.com/courses/aws-certified-cloud-practitioner-practice-exams/)
+* [CertifyQuiz](https://www.certifyquiz.com/hub/aws) — Free AWS certification practice tests with detailed explanations
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 * [AWS Cloud Practitioner Essentials (Second Edition)](https://www.aws.training/Details/Curriculum?id=27076)
 * [AWS Certified Cloud Practitioner Training Bootcamp](https://www.youtube.com/watch?v=h5jaLL0jHSQ)
 * _paid_ [A Cloud Guru course by Ryan Kroonenburg: 9.7 hours and 1 practice exam](https://acloud.guru/learn/aws-certified-cloud-practitioner)
+* - [CertifyQuiz](https://www.certifyquiz.com) — Free AWS certification practice tests with detailed explanations
 
 ### Practice Exams
 


### PR DESCRIPTION
Hi! I’d like to suggest adding a free resource for AWS certification practice.

CertifyQuiz provides free practice tests with detailed explanations, which can help candidates test their knowledge before the exam.

Let me know if it fits the list. Thanks for maintaining this awesome resource!
