### PR TITLE
Add CertPrepNow practice exams for CLF-C02, SAA-C03, SAP-C02

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 * _paid_ [Tutorials Dojo 4 practice exams by Jon Bonso](https://portal.tutorialsdojo.com/courses/aws-certified-cloud-practitioner-practice-exams/)
 * [CertifyQuiz](https://www.certifyquiz.com/hub/aws) — Free AWS certification practice tests with detailed explanations
 * [QuizForge.ai](https://quizforge.ai) — Free CLF practice exams generated from the official exam blueprint, with answer explanations in English, Spanish, or Hindi
+* [CertPrepNow](https://certprepnow.com) — Free CLF-C02 practice exams with detailed explanations
 
 ### Notes
 
@@ -167,6 +168,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 * [Exam topics +500 questions (mostly accessible without Login)](https://www.examtopics.com/exams/amazon/aws-certified-solutions-architect-associate-saa-c02/)
 * _paid_ [Tutorials Dojo 5 practice exams by Jon Bonso](https://portal.tutorialsdojo.com/courses/aws-certified-solutions-architect-associate-practice-exams/)
 * [QuizForge.ai](https://quizforge.ai) — Free SAA practice questions generated from the official exam blueprint, with explanations in English, Spanish, or Hindi
+* [CertPrepNow](https://certprepnow.com) — Free SAA-C03 practice exams with detailed explanations
 
 ### Notes
 
@@ -202,6 +204,7 @@ We encourage you to contribute to Awesome AWS Certifications! Please check out t
 * [Exam topics +400 questions (mostly accessible without Login)](https://www.examtopics.com/exams/amazon/aws-certified-developer-associate/)
 * _paid_ [Tutorials Dojo 4 practice exams by Jon Bonso](https://portal.tutorialsdojo.com/courses/aws-certified-developer-associate-practice-exams/)
 * _paid_ [DigitalCloud Training practice exams (+350 questions)](https://digitalcloud.training/courses/aws-certified-developer-associate-practice-exams/)
+* [CertPrepNow](https://certprepnow.com) — Free SAP-C02 practice exams with detailed explanations
 
 ### Notes
 


### PR DESCRIPTION
## Resource

  CertPrepNow - https://certprepnow.com

  ## What is this

  Free practice exams for AWS CLF-C02, SAA-C03, and SAP-C02 with detailed explanations for every question. No account or payment required.

  ## Why should this be added

  There are very few free practice exam resources in this list. CertPrepNow offers 500+ questions per AWS certification, all with detailed explanations, completely free and without requiring
  signup. Similar to CertifyQuiz and QuizForge.ai which are already listed.